### PR TITLE
Add deploy time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const spawnSync = require('child_process').spawnSync;
+const { DateTime } = require("luxon");
 
 class GitVersionOnDeploy {
   constructor(serverless) {
@@ -34,7 +35,8 @@ class GitVersionOnDeploy {
         return;
     }
     const git_id = gitResults.stdout.trim();
-    versionFileContents = `{ "gitVersion": "${git_id}" }`;
+    const deploy_time = DateTime.local().setZone('America/Los_Angeles').toISO();
+    versionFileContents = `{ "gitVersion": "${git_id}", "deployTime": "${deploy_time}"}`;
 
     fs.writeFileSync(this.filePath, versionFileContents);
     this.serverless.cli.log(`Tagged with git version ${git_id}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hughescr/serverless-plugin-git-version-json",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A serverless plugin which will temporarily create a file git_version.json containing the output of `git describe --tags --dirty` and include it in the package",
   "main": "index.js",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,11 @@ lodash@^4.17.14, lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+luxon@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.24.1.tgz#a8383266131ed4eaed4b5f430f96f3695403a52a"
+  integrity sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg==
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"


### PR DESCRIPTION
@hughescr 

I know we talked about this before and I figured the best place to add a deploy time was the git version. If you think it's inappropriate for the plugin I can just make a clone of your project essentially that only handles deploy time?

Example of the output of git_version.json

`{ "gitVersion": "4.0.0-rc7-3-gc7378cda-dirty", "deployTime": "2020-08-13T11:14:56.241-07:00"}`